### PR TITLE
Restylise and polish the ssh and gpg guides, and minor add to macos readme.

### DIFF
--- a/.MacOS/README.md
+++ b/.MacOS/README.md
@@ -1,8 +1,24 @@
 # [MacOS _specific_ dotfiles](https://github.com/Skenvy/dotfiles/tree/main/.MacOS)
-> [!WARNING]
+> [!CAUTION]
 > Some of the examples here might only be relevant to this's [`home`](https://github.com/Skenvy/dotfiles/tree/home) and not part of this's [`main`](https://github.com/Skenvy/dotfiles/tree/main)
 
 These are general instructions relevant to `MacOS` setup. You probably want to track your own brews. My stuff for these live in my [`home`](https://github.com/Skenvy/dotfiles/tree/home) but I've left the instructions in [`main`](https://github.com/Skenvy/dotfiles/tree/main).
+## [Bash](https://github.com/apple-oss-distributions/bash)
+[Zsh](https://www.zsh.org/) has been the "default shell" since [Catalina](https://support.apple.com/en-au/102360).
+
+I prefer bash, or, at least, I prefer not needing to maintain both bash and zsh files, and zsh is not the default on Ubuntu. And this was initialised as close to Ubuntu's skel as possible.
+
+However...
+
+> [!IMPORTANT]
+> MacOS uses an _ancient_ [version](https://github.com/apple-oss-distributions/bash/blob/main/version.h) of bash.
+> `3.2.57`.
+
+You can map from a given `macOS` release on the [Releases](https://opensource.apple.com/releases/) page by expanding the drop downs and searching for `bash-`, which will link to a specific tag on Apple's [bash](https://github.com/apple-oss-distributions/bash) source mirror/fork.
+
+At the time of writing, it's close to 20 years old for the major version.
+[Bash](https://www.gnu.org/software/bash/) [[source](https://cgit.git.savannah.gnu.org/cgit/bash.git/)] [[manual](https://www.bashcookbook.com/bashinfo/source/bash-3.2/doc/bashref.pdf)] `3.2.0` was released 28th September 2006. `3.2.57`, the patch that MacOS is frozen on since, can be seen on the [index](https://ftp.gnu.org/gnu/bash/) as released on the 7th of November 2014.
+
 ## [Homebrew](https://brew.sh/)
 * See your brews at [~/.MacOS/Brewfile](https://github.com/Skenvy/dotfiles/blob/main/.MacOS/Brewfile).
 * Restore brews

--- a/.gnupg/README.md
+++ b/.gnupg/README.md
@@ -24,19 +24,20 @@ See the docs on:
 ## First time setup
 > [!CAUTION]
 > This section is only relevant if you are setting up your dotfiles repo to check-in your `~/.gnupg/*.conf`.
-> Or to read about GitHub's vigilant mode.
 > If you are not, then the rest of this guide is still situationally useful, but this section will be irrelevant.
+>
+> Because these subsections are only contextually relevant to this repository's "dotfile repository pattern" rather than being generically applicable to setting up GPG, they are collapsed `<details>` blocks, to avoid someone reading them without reading this context aware preface and falsely assuming that understanding them is a necessary step before following the rest of this guide.
 ### Dotfiles
+
+<details>
+
+<summary>How to check-in your gpg conf files according to this repo's dotfile pattern</summary>
+
 To check-in our user config for GPG, `~/.gnupg/*.conf`, without being able to make use of our [dotfile inclusion methodology](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#include) _because GPG does not have any sort of inclusion mechanism_, yet still adhere to both patterns that we support (where this repo is either `$HOME` itself or a submodule that we symlink into `$HOME` with clobber protection), we must use the [`CLOBBER_CHECKEDIN_ROOT_IGNORELIST` option](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#dotfiles-submodule-symlinks) in our [submodule support script](./bin/dotfiles-submodule-symlinks) (see the example  [base dotfiles-submodule-symlinks-hook](https://github.com/Skenvy/dotfiles/blob/base/.include/dotfiles-submodule-symlinks-hook.sh) where you would need to list any gpg config files you would add to a repository that would submodule this one).
 
 The first time you run gpg it may or may not create any of the config files and populate them with some options. Most notably `use-keyboxd` is a default option that will frequently appear in `common.conf` these days.
 
-### Vigilant mode
-> [!IMPORTANT]
-> Don't let someone else impersonate you!
-> See GitHub's [Enabling "vigilant mode"](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#enabling-vigilant-mode) docs.
-
-Anyone can `git commit` with settings that will label their commits with your identity and `git push` them to any repository, which will show up as if _you_ authored the commit! Setting up gpg is not just to provide a method of guaranteeing authorship from the perspective solely of a repository maintainer / organisation, but also of guaranteeing that only commits you sign are demonstrably authored by you. Setting "vigilant mode" in GitHub will still allow non-signed commits claiming to be authored by you to be pushed, but they will display a status next to them that clearly marks them as "unverified" commits.
+</details>
 
 ### Symlink setup
 
@@ -48,6 +49,13 @@ WSL doesn't currently have anything that matches `/etc/skel/.gnupg/*`, so for WS
 
 </details>
 
+## First time setup: GitHub specific
+### Vigilant mode
+> [!IMPORTANT]
+> Don't let someone else impersonate you!
+> See GitHub's [Enabling "vigilant mode"](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits#enabling-vigilant-mode) docs.
+
+Anyone can `git commit` with settings that will label their commits with your identity and `git push` them to any repository, which will show up as if _you_ authored the commit! Setting up gpg is not just to provide a method of guaranteeing authorship from the perspective solely of a repository maintainer / organisation, but also of guaranteeing that only commits you sign are demonstrably authored by you. Setting "vigilant mode" in GitHub will still allow non-signed commits claiming to be authored by you to be pushed, but they will display a status next to them that clearly marks them as "unverified" commits.
 ## Install
 Install with the following, and use these commands to diagnose where you've installed to!
 

--- a/.gnupg/README.md
+++ b/.gnupg/README.md
@@ -21,12 +21,17 @@ See the docs on:
 * [Sonatype: GPG](https://central.sonatype.org/publish/requirements/gpg/) (includes steps on "expired keys")
 * [Example: bfrg/gpg-guide](https://github.com/bfrg/gpg-guide)
 
-## First time setup
+## Dotfiles setup
 > [!CAUTION]
-> This section is only relevant if you are setting up your dotfiles repo to check-in your `~/.gnupg/*.conf`.
+> This "Dotfiles setup" section is only relevant if you are setting up your dotfiles repo to check-in your `~/.gnupg/*.conf`.
 > If you are not, then the rest of this guide is still situationally useful, but this section will be irrelevant.
 >
 > Because these subsections are only contextually relevant to this repository's "dotfile repository pattern" rather than being generically applicable to setting up GPG, they are collapsed `<details>` blocks, to avoid someone reading them without reading this context aware preface and falsely assuming that understanding them is a necessary step before following the rest of this guide.
+
+<details>
+
+<summary><i>I acknowledged the caution but want to read this section anyway</i></summary>
+
 ### Dotfiles
 
 <details>
@@ -49,7 +54,9 @@ WSL doesn't currently have anything that matches `/etc/skel/.gnupg/*`, so for WS
 
 </details>
 
-## First time setup: GitHub specific
+</details>
+
+## GitHub specific setup
 ### Vigilant mode
 > [!IMPORTANT]
 > Don't let someone else impersonate you!

--- a/.gnupg/README.md
+++ b/.gnupg/README.md
@@ -36,11 +36,11 @@ See the docs on:
 
 <details>
 
-<summary>How to check-in your gpg conf files according to this repo's dotfile pattern</summary>
+<summary><i>How to check-in your gpg conf files according to this repo's dotfile pattern</i></summary>
 
-To check-in our user config for GPG, `~/.gnupg/*.conf`, without being able to make use of our [dotfile inclusion methodology](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#include) _because GPG does not have any sort of inclusion mechanism_, yet still adhere to both patterns that we support (where this repo is either `$HOME` itself or a submodule that we symlink into `$HOME` with clobber protection), we must use the [`CLOBBER_CHECKEDIN_ROOT_IGNORELIST` option](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#dotfiles-submodule-symlinks) in our [submodule support script](./bin/dotfiles-submodule-symlinks) (see the example  [base dotfiles-submodule-symlinks-hook](https://github.com/Skenvy/dotfiles/blob/base/.include/dotfiles-submodule-symlinks-hook.sh) where you would need to list any gpg config files you would add to a repository that would submodule this one).
-
-The first time you run gpg it may or may not create any of the config files and populate them with some options. Most notably `use-keyboxd` is a default option that will frequently appear in `common.conf` these days.
+> To check-in our user config for GPG, `~/.gnupg/*.conf`, without being able to make use of our [dotfile inclusion methodology](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#include) _because GPG does not have any sort of inclusion mechanism_, yet still adhere to both patterns that we support (where this repo is either `$HOME` itself or a submodule that we symlink into `$HOME` with clobber protection), we must use the [`CLOBBER_CHECKEDIN_ROOT_IGNORELIST` option](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#dotfiles-submodule-symlinks) in our [submodule support script](./bin/dotfiles-submodule-symlinks) (see the example  [base dotfiles-submodule-symlinks-hook](https://github.com/Skenvy/dotfiles/blob/base/.include/dotfiles-submodule-symlinks-hook.sh) where you would need to list any gpg config files you would add to a repository that would submodule this one).
+>
+> The first time you run gpg it may or may not create any of the config files and populate them with some options. Most notably `use-keyboxd` is a default option that will frequently appear in `common.conf` these days.
 
 </details>
 
@@ -48,9 +48,14 @@ The first time you run gpg it may or may not create any of the config files and 
 
 <details>
 
-<summary>... or why we DON'T symlink for gpg.</summary>
+<summary><i>... or why we DON'T symlink for gpg.</i></summary>
 
-WSL doesn't currently have anything that matches `/etc/skel/.gnupg/*`, so for WSL's perpective, we'd need to make these files ourselves if we care to. However, Windows installations of GPG use `~/AppData/Roaming/gnupg/*`. We could theoretically support a "single point of config" by symlinking our Windows `~/AppData/Roaming/gnupg/*` to WSL `~/.gnupg/*`, and this would be the simplest way to have both be aware of the same keys. However, the versions of gpg that can be installed on windows, in Ubuntu, and come pre-included in "git bash" all appear to have slight variations in their version and internal key-store. On top of this, the version of gpg that comes with "git bash" uses the Windows home folder's `~/.gnupg` the same as in WSL / Mac, which would clash with any attempt to symlink WSL's `~/.gnupg` and Windows `~/AppData/Roaming/gnupg/*` to Windows `~/.gnupg`. For example my current installation of git-bash includes a gpg version old enough that it does not work with the `keyboxd` setting, which is now the _default_ setting in the versions of gpg that are already installed in WSL, Mac's latest brew, _and_ the latest Windows build.
+> WSL doesn't currently have anything that matches `/etc/skel/.gnupg/*`, so for WSL's perpective, we'd need to make these files ourselves if we care to.
+> However, Windows installations of GPG use `~/AppData/Roaming/gnupg/*`.
+> We could theoretically support a "single point of config" by symlinking our Windows `~/AppData/Roaming/gnupg/*` to WSL `~/.gnupg/*`, and this would be the simplest way to have both be aware of the same keys.
+> However, the versions of gpg that can be installed on windows, in Ubuntu, and come pre-included in "git bash" all appear to have slight variations in their version and internal key-store.
+> On top of this, the version of gpg that comes with "git bash" uses the Windows home folder's `~/.gnupg` the same as in WSL / Mac, which would clash with any attempt to symlink WSL's `~/.gnupg` and Windows `~/AppData/Roaming/gnupg/*` to Windows `~/.gnupg`.
+> For example my current installation of git-bash includes a gpg version old enough that it does not work with the `keyboxd` setting, which is now the _default_ setting in the versions of gpg that are already installed in WSL, Mac's latest brew, _and_ the latest Windows build.
 
 </details>
 
@@ -73,13 +78,17 @@ We'll need to know the path that gpg was installed to later when setting the git
     * get the path with `which -a gpg` (and `type gpg`)
 1. For Windows, the "Simple installer for the current GnuPG" on the [gnupg downloads](https://www.gnupg.org/download/) page is the easiest option.
     * get the path with `where gpg` (cmd) or `(Get-Command gpg).source` (pwsh)
+    * If you need a specific _version_ you can find all versions [here](https://www.gnupg.org/ftp/gcrypt/binary).
+        * They are versioned `gnupg-w32-*_*.exe`.
+        * First by the version's semver, and then by build date.
+        * At the time this was initially written: `2.4.8` was the latest.
 
 > [!WARNING]
 > For Windows users, the included pin-entry program may not function properly if it is installed without specifically installing it as an admin. So make sure you install it as admin to ensure the pin-entry program works!
 >
 > If you install the "Simple installer ..." as an admin, it should by default end up in `C:\Program Files (x86)\GnuPG\bin\gpg.exe`. If you install it without elevating to admin it will install to your user specific `AppData/Local` folder.
 >
-> If you have an install in your `AppData/Local` and you're experiencing issues with pin-entry, delete that install, clear the path entries for it, and reinstall as admin.
+> **If you have an install in your `AppData/Local` and you're experiencing issues with pin-entry, delete that, or all, install(s), clear the path entries for it, and reinstall as admin.**
 >
 > Regardless of install location, `gpg --version` on Windows will tell you your `HOME` is in your `AppData/Roaming`. This is expected.
 

--- a/.gnupg/README.md
+++ b/.gnupg/README.md
@@ -83,15 +83,19 @@ We'll need to know the path that gpg was installed to later when setting the git
         * First by the version's semver, and then by build date.
         * At the time this was initially written: `2.4.8` was the latest.
 
+### Windows install quirks
+#### Windows pin-entry issue
 > [!WARNING]
 > For Windows users, the included pin-entry program may not function properly if it is installed without specifically installing it as an admin. So make sure you install it as admin to ensure the pin-entry program works!
 >
 > If you install the "Simple installer ..." as an admin, it should by default end up in `C:\Program Files (x86)\GnuPG\bin\gpg.exe`. If you install it without elevating to admin it will install to your user specific `AppData/Local` folder.
->
+#### Windows pin-entry issue first fix to try!
+> [!CAUTION]
 > **If you have an install in your `AppData/Local` and you're experiencing issues with pin-entry, delete that, or all, install(s), clear the path entries for it, and reinstall as admin.**
->
-> Regardless of install location, `gpg --version` on Windows will tell you your `HOME` is in your `AppData/Roaming`. This is expected.
-
+#### Windows `HOME` is _supposed to be_ `AppData/Roaming`
+> [!NOTE]
+> _**Regardless**_ of install location, `gpg --version` on Windows will tell you your `HOME` is in your `AppData/Roaming`. This is _**expected**_, and _**not an issue**_, like the presence of a broken install in `AppData/Local` is an issue.
+#### Windows users should _**avoid**_ `git bash`
 > [!CAUTION]
 > For Windows users we specifically recommend _against_ using the version of gpg packaged with `git bash`, that would have been installed by [git for windows](https://git-scm.com/install/windows), as it can be significantly older than the current version on the [gnupg downloads](https://www.gnupg.org/download/) page, and it uses a different internal format to store keys. It will be the default gpg used by git inside of the `git bash` program, but will be difficult to use _outside_ of `git bash`.
 >

--- a/.ssh/README.md
+++ b/.ssh/README.md
@@ -79,16 +79,85 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 
 </details>
 
+## Be aware
+> [!TIP]
+> You only truly need to be "aware" of all these things if you're following this whole guide as a single cohesive strategy.
+>
+> If you already know what you came here for, or just to read a specific example, then you probably don't "need to be aware."
+
+> [!CAUTION]
+> If you're following on a Mac, follow the `bash` examples, and the other examples will be irrelevant.
+>
+> If you're on a WSL and only want to work in WSL and skip Windows, also just focus on the `bash` examples.
+>
+> If you're on Windows, and you _don't want to use WSL_ then you'll need to follow the `cmd` and/or `pwsh` alternatives.
+>
+> If you're setting up WSL _AND_ Windows _together_, you will have additional setup requirements in the below 'Be "Home Aware"' warning.
+
+> [!TIP]
+> The below are micro explanations to justify this TLDR.
+### Be "OS Aware"
+> [!WARNING]
+> Although this guide is "about" SSH, it is, broadly, _geared_ towards _enabling_ WSL.
+>
+> This doesn't really sacrifice any clarity, because all the example commands given for WSL should all work in Mac's [_ancient_ version of bash](https://github.com/Skenvy/dotfiles/tree/main/.MacOS#bash) as well.
+>
+> So Mac and WSL "only" should be equivalent.
+### Be "Shell Aware"
+> [!WARNING]
+> WSL lives inside Windows, _not_ Mac, and quite a lot of commands later are specifically intended for running in _either_ of the two, unique, Windows shells; `cmd` or `pwsh`, but not both.
+>
+> Ideally a code example should either state or be _overwhelming_ implied, as to whether an example is intended for `bash` in either case of WSL or MacOS, or specifically which of the differently behaving `cmd` or `pwsh` in Windows cases.
+>
+> So Windows users will need to be cognizant of _which_ of the two different "Windows shells", `cmd` or `pwsh`, they are using, for each individual example.
+### Be "Home Aware"
+> [!WARNING]
+> If you're setting up WSL _AND_ Windows _together_, and you want to have them _share_ keys, you'll need to be aware of which HOME you're using in any given context.
+>
+> "HOME" will be different from your Windows and WSL's perspective: the `~/.ssh` you navigate to from inside WSL will be different from the `~/.ssh` you navigate to outside of WSL.
+>
+> If you want both WSL and Windows to share the _SAME_ `~/.ssh`, this is possible!
+>
+> WSL can utilise symlinks to setup its own internal view of what _its_ `~/.ssh` is, by setting it as a symlink to the fully realised path of what would be `~/.ssh` from Window's perspective. Windows "junctions" can't reach inside of WSL's filesystem, so in any case, Windows `~/.ssh` will have to be the source of truth, and WSL will have to be told to use it too.
+>
+> If you truly do want to do this, two different strategies are suggested in the above ["Dotfiles Setup"](#dotfiles-setup) section.
+>
+> If you aren't sure yet, or don't want to do this quite yet, if you follow setting up the Windows only side of things, the symlinking strategies in the above ["Dotfiles Setup"](#dotfiles-setup) section can be done at any point in time afterwards, they don't need to be done concurrently.
+>
+> Once both Windows and WSL's `~/.ssh` are symlinked, assuming you chose this, you can access the same keys from both, and you can follow the `bash` steps where both `bash` and `cmd`|`pwsh` are available for something.
+
 ## Creating a new key
-To connect from "this machine" to a new GH account. While `~` will be different from your Windows and WSL's perspective, WSL's `~/.ssh` _should_ be a **soft link** to your window's `~/.ssh`, so it's ok to use either.
+In `bash`
 ```bash
 # Make the key
 EMAIL=your_email@example.com
 KEYNAME=GH_Username
 ssh-keygen -t ed25519 -C "$EMAIL" -f ~/.ssh/$KEYNAME
 ```
+In `pwsh`
+```pwsh
+# Make the key
+$EMAIL = "your_email@example.com"
+$KEYNAME = "GH_Username"
+ssh-keygen -t ed25519 -C "$EMAIL" -f "$HOME/.ssh/$KEYNAME"
+```
+In `cmd`
+```cmd
+set EMAIL=your_email@example.com
+set KEYNAME=GH_Username
+ssh-keygen -t ed25519 -C "%EMAIL%" -f "%userprofile%\.ssh\%KEYNAME%"
+```
 ## Upload the public key
-Upload the public key `cat ~/.ssh/$KEYNAME.pub` to https://github.com/settings/ssh/new as an "Authentication Key" with some name.
+Upload the public key to https://github.com/settings/ssh/new as an "Authentication Key" with some name.
+### Get the contents
+In `bash` or `pwsh` (assuming you still have `KEYNAME` set from creating above)
+```bash
+cat ~/.ssh/$KEYNAME.pub
+```
+In `cmd` (assuming you still have `KEYNAME` set from creating above)
+```cmd
+type "%userprofile%\.ssh\%KEYNAME%.pub"
+```
 ## Add the new key to the ssh-agent
 ### Enable `chmod`'ing' the keys stored in Windows filesystem from WSL
 If you're going to `chmod` you might need to add the following to `sudo vi /etc/wsl.conf` from WSL

--- a/.ssh/README.md
+++ b/.ssh/README.md
@@ -1,4 +1,4 @@
-# SSH
+# [SSH](https://github.com/Skenvy/dotfiles/blob/main/.ssh/README.md)
 > [!NOTE]
 > These tips _originally_ started in [this gist](https://gist.github.com/Skenvy/8e16d4f044707e63c670f5b487da02c0#ssh).
 >
@@ -21,13 +21,33 @@ See the docs on:
 
 ## First time setup
 > [!CAUTION]
-> This section is only relevant if you are setting up your dotfiles repo to check-in your `~/.ssh/config`, or looking for the discussion on sharing keys between `WSL` and `Windows`.
+> This "First time setup" section is only relevant if you are setting up your dotfiles repo to check-in your `~/.ssh/config`.
 > If you are not, then the rest of this guide is still situationally useful, but this section will be irrelevant.
+>
+> Because these subsections are only contextually relevant to this repository's "dotfile repository pattern" rather than being generically applicable to setting up SSH, they are collapsed `<details>` blocks, to avoid someone reading them without reading this context aware preface and falsely assuming that understanding them is a necessary step before following the rest of this guide.
+
+<details>
+
+<summary>I've read the caution but want to read this section anyway</summary>
+
 ### Dotfiles
+
+<details>
+
+<summary>How to check-in your ssh config file according to this repo's dotfile pattern</summary>
+
 To check-in our only user config for SSH, `~/.ssh/config`, in such a way that it can be extended when _this_ repo's [dotfile inclusion methodology](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#include) is followed, we make use of SSH's `Include` directive in our checked-in `~/.ssh/config`.
 
 To make it easier to use the same keys between a `Windows` machine and a `WSL` instance on it, we can symlink the keys _from_ Windows to WSL. If you would rather manually copy each of the keys as you make them, that won't interfere with the config being checked in, but it will mean the rest of this "setup" section will be irrelevant.
-### Symlink the _whole_ directory (NOT checked-in config)
+
+</details>
+
+### WSL: Symlink the _whole_ directory
+
+<details>
+
+<summary>The simpler option, which does NOT check-in config</summary>
+
 If you are looking for how to symlink your whole SSH folder from Windows to WSL to use the same keys and config, but are not bothered with checking-in your config, then the easiest option is the following, which DOESN'T support checked-in config.
 
 From within WSL;
@@ -37,7 +57,15 @@ YOUR_WINDOWS_USERNAME=example
 mkdir -p /mnt/c/Users/$YOUR_WINDOWS_USERNAME/.ssh
 ln -s /mnt/c/Users/$YOUR_WINDOWS_USERNAME/.ssh ~/.ssh
 ```
-### Symlink each file/folder in the ssh folder (YES checked-in config)
+
+</details>
+
+### WSL: Symlink each file/folder in the ssh folder
+
+<details>
+
+<summary>The less simple option, which DOES check-in config</summary>
+
 To support periodically re-symlinking all files (except for `~/.ssh/config` and _this file_ (`~/.ssh/README`)) from my Windows `~/.ssh` to my WSL's `~/.ssh`, I make use of the following two aliases, which require a `LOCAL_WINDOWS_USERNAME` to be set [somewhere](https://github.com/Skenvy/dotfiles/tree/main/.include/.pre#bashrc) (e.g. I personally set mine in my `~/.include/.pre/.bashrc`);
 ```bash
 # LOCAL_WINDOWS_USERNAME set in some bashrc before these aliases are used
@@ -46,6 +74,11 @@ alias wsl_resym_ssh="( shopt -s dotglob; WINDOWS_PATH=\"/mnt/c/Users/\$LOCAL_WIN
 ```
 If you're using this repository as a template for your own dotfiles, these aliases exist in my [`home`](https://github.com/Skenvy/dotfiles/blob/home/.bash_aliases) but I don't keep aliases in the `main` branch because they are too flavoured for what is supposed to be a bland/basic `main`.
 Note that the alias `wsl_resym_ssh` only works as expected while we only track files directly in the `.ssh` folder, and would break if we checked-in anything nested in a folder. This works here because all I have accounted for checking in is my `~/.ssh/config` and this `~/.ssh/README.md`.
+
+</details>
+
+</details>
+
 ## Creating a new key
 To connect from "this machine" to a new GH account. While `~` will be different from your Windows and WSL's perspective, WSL's `~/.ssh` _should_ be a **soft link** to your window's `~/.ssh`, so it's ok to use either.
 ```bash

--- a/.ssh/README.md
+++ b/.ssh/README.md
@@ -19,16 +19,16 @@ See the docs on:
 * [SSH's "include" directive](https://man.openbsd.org/ssh_config#Include)
 * [Using ssh with vs code devcontainers](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials)
 
-## First time setup
+## Dotfiles setup
 > [!CAUTION]
-> This "First time setup" section is only relevant if you are setting up your dotfiles repo to check-in your `~/.ssh/config`.
+> This "Dotfiles setup" section is only relevant if you are setting up your dotfiles repo to check-in your `~/.ssh/config`.
 > If you are not, then the rest of this guide is still situationally useful, but this section will be irrelevant.
 >
 > Because these subsections are only contextually relevant to this repository's "dotfile repository pattern" rather than being generically applicable to setting up SSH, they are collapsed `<details>` blocks, to avoid someone reading them without reading this context aware preface and falsely assuming that understanding them is a necessary step before following the rest of this guide.
 
 <details>
 
-<summary>I've read the caution but want to read this section anyway</summary>
+<summary><i>I acknowledged the caution but want to read this section anyway</i></summary>
 
 ### Dotfiles
 

--- a/.ssh/README.md
+++ b/.ssh/README.md
@@ -79,12 +79,7 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 
 </details>
 
-## Be aware
-> [!TIP]
-> You only truly need to be "aware" of all these things if you're following this whole guide as a single cohesive strategy.
->
-> If you already know what you came here for, or just to read a specific example, then you probably don't "need to be aware."
-
+## Be "aware" (of which examples in this you want to use)
 > [!CAUTION]
 > If you're following on a Mac, follow the `bash` examples, and the other examples will be irrelevant.
 >
@@ -94,23 +89,48 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 >
 > If you're setting up WSL _AND_ Windows _together_, you will have additional setup requirements in the below 'Be "Home Aware"' warning.
 
-> [!TIP]
+> [!NOTE]
 > The below are micro explanations to justify this TLDR.
+>
+> You only truly need to be "aware" of all these things if you're following this whole guide as a single cohesive strategy.
+>
+> If you already know what you came here for, or just to read a specific example, then you probably don't "need to be aware."
 ### Be "OS Aware"
+
+<details>
+
+<summary><i>Why Mac and WSL "only" should both follow the <code>bash</code> examples</i></summary>
+
 > [!WARNING]
 > Although this guide is "about" SSH, it is, broadly, _geared_ towards _enabling_ WSL.
 >
 > This doesn't really sacrifice any clarity, because all the example commands given for WSL should all work in Mac's [_ancient_ version of bash](https://github.com/Skenvy/dotfiles/tree/main/.MacOS#bash) as well.
 >
 > So Mac and WSL "only" should be equivalent.
+
+</details>
+
 ### Be "Shell Aware"
+
+<details>
+
+<summary><i>Acknowledging that <code>cmd</code> and <code>pwsh</code> are not interchangeable</i></summary>
+
 > [!WARNING]
 > WSL lives inside Windows, _not_ Mac, and quite a lot of commands later are specifically intended for running in _either_ of the two, unique, Windows shells; `cmd` or `pwsh`, but not both.
 >
 > Ideally a code example should either state or be _overwhelming_ implied, as to whether an example is intended for `bash` in either case of WSL or MacOS, or specifically which of the differently behaving `cmd` or `pwsh` in Windows cases.
 >
 > So Windows users will need to be cognizant of _which_ of the two different "Windows shells", `cmd` or `pwsh`, they are using, for each individual example.
+
+</details>
+
 ### Be "Home Aware"
+
+<details>
+
+<summary><i>Windows <code>~/</code> is different from WSL's <code>~/</code>. Know which one you're in!</i></summary>
+
 > [!WARNING]
 > If you're setting up WSL _AND_ Windows _together_, and you want to have them _share_ keys, you'll need to be aware of which HOME you're using in any given context.
 >
@@ -125,6 +145,8 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 > If you aren't sure yet, or don't want to do this quite yet, if you follow setting up the Windows only side of things, the symlinking strategies in the above ["Dotfiles Setup"](#dotfiles-setup) section can be done at any point in time afterwards, they don't need to be done concurrently.
 >
 > Once both Windows and WSL's `~/.ssh` are symlinked, assuming you chose this, you can access the same keys from both, and you can follow the `bash` steps where both `bash` and `cmd`|`pwsh` are available for something.
+
+</details>
 
 ## Creating a new key
 In `bash`

--- a/.ssh/README.md
+++ b/.ssh/README.md
@@ -101,7 +101,7 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 
 <summary><i>Why Mac and WSL "only" should both follow the <code>bash</code> examples</i></summary>
 
-> [!WARNING]
+<!-- > [!WARNING] -->
 > Although this guide is "about" SSH, it is, broadly, _geared_ towards _enabling_ WSL.
 >
 > This doesn't really sacrifice any clarity, because all the example commands given for WSL should all work in Mac's [_ancient_ version of bash](https://github.com/Skenvy/dotfiles/tree/main/.MacOS#bash) as well.
@@ -116,7 +116,7 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 
 <summary><i>Acknowledging that <code>cmd</code> and <code>pwsh</code> are not interchangeable</i></summary>
 
-> [!WARNING]
+<!-- > [!WARNING] -->
 > WSL lives inside Windows, _not_ Mac, and quite a lot of commands later are specifically intended for running in _either_ of the two, unique, Windows shells; `cmd` or `pwsh`, but not both.
 >
 > Ideally a code example should either state or be _overwhelming_ implied, as to whether an example is intended for `bash` in either case of WSL or MacOS, or specifically which of the differently behaving `cmd` or `pwsh` in Windows cases.
@@ -131,7 +131,7 @@ Note that the alias `wsl_resym_ssh` only works as expected while we only track f
 
 <summary><i>Windows <code>~/</code> is different from WSL's <code>~/</code>. Know which one you're in!</i></summary>
 
-> [!WARNING]
+<!-- > [!WARNING] -->
 > If you're setting up WSL _AND_ Windows _together_, and you want to have them _share_ keys, you'll need to be aware of which HOME you're using in any given context.
 >
 > "HOME" will be different from your Windows and WSL's perspective: the `~/.ssh` you navigate to from inside WSL will be different from the `~/.ssh` you navigate to outside of WSL.


### PR DESCRIPTION
* Polish the ssh and gpg readmes to be more aligned
* Add definitive examples for pwsh and cmd to the ssh examples
* Restylise a bunch of the preface descriptions for the guides themselves...
* Add a note to the macos readme outlining ancient v3 bash.