### PR TITLE
Git dotfiles uppies -- fix three ../ paths

### DIFF
--- a/git/config/apply.ps1
+++ b/git/config/apply.ps1
@@ -22,7 +22,7 @@ $THIS_SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 # There is no powershell compat checking script (yet?)
 ################################################################################
 
-$GITCONFIG = Join-Path $THIS_SCRIPT_DIR "..\\.gitconfig"
+$GITCONFIG = Join-Path $THIS_SCRIPT_DIR "..\\..\\.gitconfig"
 $GITCONFIG_INIT = "$GITCONFIG.init"
 $GITCONFIG_BASE = "$GITCONFIG.base"
 $GITCONFIG_DIFF = "$GITCONFIG.diff"

--- a/git/config/apply.sh
+++ b/git/config/apply.sh
@@ -19,10 +19,10 @@ set -eu
 ################################################################################
 # Our standard bash compat check
 THIS_SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-source $THIS_SCRIPT_DIR/../bin/system-bash-compat
+source $THIS_SCRIPT_DIR/../../bin/system-bash-compat
 ################################################################################
 
-GITCONFIG="$THIS_SCRIPT_DIR/../.gitconfig"
+GITCONFIG="$THIS_SCRIPT_DIR/../../.gitconfig"
 GITCONFIG_INIT="$GITCONFIG.init"
 GITCONFIG_BASE="$GITCONFIG.base" # Not used here, just decorative..
 GITCONFIG_DIFF="$GITCONFIG.diff"


### PR DESCRIPTION
Fixes three paths that were previously pointing to the right amount of `../` backtracks, but didn't get updated when I changed the path of the apply scripts.