### PR TITLE
Git config uppies -- fix ps1 script on windows

### DIFF
--- a/.include/.pre/README.md
+++ b/.include/.pre/README.md
@@ -28,7 +28,7 @@ LOCAL_WINDOWS_USERNAME=your-local-windows-user-name
 ```ini
 [core]
     autocrlf = true  # Checkout Windows-style, commit Unix-style
-    editor = <something like '\"C:\\Users\\<username>\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code\" --wait' (without '')> 
+    editor = code --wait # ensure code is on your path
     filemode = false
     symlinks = false
 

--- a/AppData/Roaming/Code/User/settings.json
+++ b/AppData/Roaming/Code/User/settings.json
@@ -2,5 +2,5 @@
   "dotfiles.repository": "git@github.com:Skenvy/dotfiles.git",
   "dotfiles.targetPath": "~/.dotfiles",
   "dotfiles.installCommand": "install.sh",
-  "workbench.colorTheme": "Default Dark Modern"
+  "workbench.colorTheme": "Dark Modern"
 }

--- a/git/config/README.md
+++ b/git/config/README.md
@@ -46,7 +46,9 @@ It is a somewhat common (at least, not uncommon...) practice to include a whole,
 >     * [.include/.post/.gitconfig](https://github.com/Skenvy/dotfiles/blob/main/.include/.post/README.md#gitconfig) for settings like your name, email, or gpg key ID
 > 1. Run one of the available "apply" scripts here that will bundle your inclusions together
 >     * [apply.sh](./apply.sh) for Linux/MacOS
+>         * `./git/config/apply.sh`
 >     * [apply.ps1](./apply.ps1) for Windows
+>         * `powershell.exe -ExecutionPolicy Bypass -File ".\git\config\apply.ps1"`
 > 1. If some config had been intermittently set in `~/.gitconfig` but not adopted by `~/.gitconfig.base` (or anything included by it), then these `apply.*` scripts will produce a `~/.gitconfig.diff` with the differing config captured. This is per run, so be sure to check it after each run if there was a difference!
 #### What are these steps doing under the hood?
 > [!NOTE]

--- a/git/config/apply.ps1
+++ b/git/config/apply.ps1
@@ -50,7 +50,7 @@ Copy-Item $GITCONFIG_INIT $GITCONFIG -Force
 $TARGET_STATE = (Capture-GlobalStateSansIncludes | Sort-Object) -join "`n"
 
 # Step 4: Empty ~/.gitconfig to get a clean slate
-"" | Out-File $GITCONFIG
+Remove-Item $GITCONFIG # Windows is not happy if it's just an empty file.. so completely remove it
 
 # Step 5: Write the captured global state to ~/.gitconfig (the "base" state)
 # This establishes what the default configuration should be
@@ -58,6 +58,7 @@ $TARGET_STATE -split "`n" | ForEach-Object {
     if ($_ -match "^(.+?)=(.*)$") {
         $key = $matches[1]
         $value = $matches[2]
+        # If you are getting errors, it is highly likely from escape sequence shenanigans
         git config --file $GITCONFIG $key $value
     }
 }


### PR DESCRIPTION
Fix an issue where git config is unhappy on windows if an empty file exists, and amend the recommended editor entry for windows, which previously was throwing an escape sequence curveball.