### PR TITLE
Git dotfiles uppies -- Add PowerShell 5.1 $PROFILE + aliases + other

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -11,8 +11,11 @@ source-existing-file ~/.include/.post/.bash_aliases
 alias rehome="git submodule update --remote && git add dotfiles && CLOBBER_HOME=GRACEFULLY ~/dotfiles/bin/dotfiles-submodule-symlinks && git diff --cached dotfiles && git status"
 alias rehome_undo="git restore --staged dotfiles && git restore dotfiles && git submodule update && CLOBBER_HOME=GRACEFULLY ~/dotfiles/bin/dotfiles-submodule-symlinks && git status"
 
+# For ensuring your ~/.gitconfig is up-to-date
+alias gaconf="~/git/config/apply.sh"
+
 ################################################################################
-# The above are two aliases relevant to using this repoistory as a submodule as
+# The above are some aliases relevant to using this repoistory as a submodule as
 # described by the README. For any additional aliases I use, I've added them
 # only in https://github.com/Skenvy/dotfiles/blob/home/.bash_aliases my home.
 

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,4 +1,4 @@
-source-existing-file ~/.include/.post/.bash_aliases
+source-existing-file ~/.include/.pre/.bash_aliases
 
 ################################################################################
 # Aliases used to proctor updating this repo when it's added as a submodule..

--- a/.bash_aliases
+++ b/.bash_aliases
@@ -11,7 +11,8 @@ source-existing-file ~/.include/.post/.bash_aliases
 alias rehome="git submodule update --remote && git add dotfiles && CLOBBER_HOME=GRACEFULLY ~/dotfiles/bin/dotfiles-submodule-symlinks && git diff --cached dotfiles && git status"
 alias rehome_undo="git restore --staged dotfiles && git restore dotfiles && git submodule update && CLOBBER_HOME=GRACEFULLY ~/dotfiles/bin/dotfiles-submodule-symlinks && git status"
 
-# For ensuring your ~/.gitconfig is up-to-date
+# For ensuring your ~/.gitconfig is up-to-date; per our unconvential method:
+# https://github.com/Skenvy/dotfiles/blob/main/git/config/README.md
 alias gaconf="~/git/config/apply.sh"
 
 ################################################################################

--- a/.bashrc
+++ b/.bashrc
@@ -201,7 +201,8 @@ if ! shopt -oq posix; then
 fi
 
 ##### GIT+SSH+GPG
-( source-existing-file ~/git/config/apply.sh ) # subshell to wrap sets on start
+# subshell to wrap sets on start
+( VERBOSE=false source-existing-file ~/git/config/apply.sh >/dev/null )
 
 if [ -z "$SSH_AUTH_SOCK" ] ; then
     eval `ssh-agent -s` > /dev/null

--- a/Documents/WindowsPowerShell/aliases.ps1
+++ b/Documents/WindowsPowerShell/aliases.ps1
@@ -1,0 +1,23 @@
+Invoke-Source "$HOME/.include/.pre/.pwsh_aliases" -Quiet
+
+################################################################################
+# Aliases used to proctor updating this repo when it's added as a submodule..
+# https://github.com/Skenvy/dotfiles?tab=readme-ov-file#use-as-home-is-another-repo
+# You'll need to manually run the dotfiles-submodule-symlinks the first time to
+# put the links in place (e.g. link _this_ file in place). But once you've done
+# that you can just "rehome" to update the submodule to latest.
+
+# For using this repo as a submodule
+# TODO: rehome ~ dependent on creating a pwsh equivalent of dotfiles-submodule-symlinks
+# TODO: rehome_undo ~ dependent on creating a pwsh equivalent of dotfiles-submodule-symlinks
+
+# For ensuring your ~/.gitconfig is up-to-date; per our unconvential method:
+# https://github.com/Skenvy/dotfiles/blob/main/git/config/README.md
+Set-Alias -Name gaconf -Value { & "$HOME/git/config/apply.ps1" }
+
+################################################################################
+# The above are some aliases relevant to using this repoistory as a submodule as
+# described by the README. For any additional aliases I use, I've added them
+# only in https://github.com/Skenvy/dotfiles/blob/home/.bash_aliases my home.
+
+Invoke-Source "$HOME/.include/.post/.pwsh_aliases" -Quiet

--- a/Documents/WindowsPowerShell/profile.ps1
+++ b/Documents/WindowsPowerShell/profile.ps1
@@ -1,0 +1,30 @@
+# This is a $PROFILE.CurrentUserAllHosts script, exceuted by PowerShell (5.1)
+
+$ProfileDir = Split-Path -Path $PROFILE.CurrentUserAllHosts -Parent
+
+function Invoke-Source {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [string]$Path,
+        [Parameter(Mandatory = $false)]
+        [switch]$Quiet
+    )
+    # Resolve the path to handle relative and variable paths correctly, into abs
+    $ResPath = Resolve-Path -Path $Path -ErrorAction SilentlyContinue
+    if ($ResPath -and (Test-Path -Path $ResPath.Path -PathType Leaf)) {
+        # Dot-source the file into the current scope
+        . $ResPath.Path
+        if (-not $Quiet) {
+            Write-Verbose "Successfully sourced: $($ResPath.Path)"
+        }
+    } else {
+        if (-not $Quiet) {
+            Write-Warning "Cannot source file. Path does not exist or is not a file: $Path"
+        }
+    }
+}
+
+# Get aliases.
+$AliasFile  = Join-Path -Path $ProfileDir -ChildPath "aliases.ps1"
+Invoke-Source $AliasFile -Quiet

--- a/bin/dotfiles-submodule-symlinks
+++ b/bin/dotfiles-submodule-symlinks
@@ -106,15 +106,27 @@ echo "Looking for a $SYSTEM_BASH_COMPAT_BIN to run the guard..."
 # We needed to know the _SUBMOD path before calling system-bash-compat
 # Favour calling the copy in the submodule state
 if [ -f "$_SUBMOD/$SYSTEM_BASH_COMPAT_BIN" ]; then
+  echo "Found and running $_SUBMOD/$SYSTEM_BASH_COMPAT_BIN"
   source $_SUBMOD/$SYSTEM_BASH_COMPAT_BIN
 else
   # If it doesn't exist in the submodule state, try root repository.
+  echo "Missing submodule copy $_SUBMOD/$SYSTEM_BASH_COMPAT_BIN"
   if [ -f "$REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN" ]; then
+    echo "Found and running $REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN"
     source $REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN
   else
-    # if it was in neither the submod or root, something went wrong
-    echo "Couldn't locate system-bash-compat, is your submodule up to date?"
-    exit 127
+    # If it was in neither the submod or root, something went wrong. As a final
+    # alternative, check if there is a system-bash-compat adjacent to this...
+    echo "Missing repository root copy $REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN"
+    THIS_SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")" # but back out one..
+    if [ -f "$THIS_SCRIPT_DIR/../$SYSTEM_BASH_COMPAT_BIN" ]; then
+      echo "Found and running $THIS_SCRIPT_DIR/../$SYSTEM_BASH_COMPAT_BIN"
+      source $THIS_SCRIPT_DIR/../$SYSTEM_BASH_COMPAT_BIN
+    else
+      echo "Missing adjacent copy $THIS_SCRIPT_DIR/../$SYSTEM_BASH_COMPAT_BIN"
+      echo "Couldn't locate system-bash-compat, is your submodule up to date?"
+      exit 127
+    fi
   fi
 fi
 

--- a/bin/dotfiles-submodule-symlinks
+++ b/bin/dotfiles-submodule-symlinks
@@ -20,7 +20,12 @@
 # hand does not have a system bash that supports these. It's stuck on an ancient
 # version of bash (v3.2.*). We support this with in-situ swapsies. So just check
 # we're in an environment we expect to be compatible.
-source ./bin/system-bash-compat
+
+# source ./bin/system-bash-compat # << typically how this would be called, but
+#     # << we need to handle this being intended for existing in a submodule.
+#     # << See lower down for how we make sure we find `system-bash-compat`.
+SYSTEM_BASH_COMPAT_BIN=bin/system-bash-compat
+
 # If you need to configure either PROCTOR_OLD_BASH or PROCTOR_BSD_UTIL see the
 # compat script's hook description.
 ################################################################################
@@ -96,6 +101,22 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 _PWD="$(pwd)" # ~= "~"
 _SUBMOD="$_PWD/$SUBMOD_PATH" # ~= "~/dotfiles"
 _HOOK_SOURCE="$_PWD/$DSS_HOOKIN_SOURCE"
+
+echo "Looking for a $SYSTEM_BASH_COMPAT_BIN to run the guard..."
+# We needed to know the _SUBMOD path before calling system-bash-compat
+# Favour calling the copy in the submodule state
+if [ -f "$_SUBMOD/$SYSTEM_BASH_COMPAT_BIN" ]; then
+  source $_SUBMOD/$SYSTEM_BASH_COMPAT_BIN
+else
+  # If it doesn't exist in the submodule state, try root repository.
+  if [ -f "$REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN" ]; then
+    source $REPO_ROOT/$SYSTEM_BASH_COMPAT_BIN
+  else
+    # if it was in neither the submod or root, something went wrong
+    echo "Couldn't locate system-bash-compat, is your submodule up to date?"
+    exit 127
+  fi
+fi
 
 echo # Newline
 echo "SUBMODULE PATH IS SET TO $SUBMOD_PATH"

--- a/bin/system-bash-compat
+++ b/bin/system-bash-compat
@@ -25,11 +25,11 @@ set -o pipefail # Exit codes cascade through pipelines.
 VERBOSE="${VERBOSE:-true}"
 
 vecho() {
-  [[ "$VERBOSE" == "true" ]] && echo "$@"
+  [[ "$VERBOSE" == "true" ]] && echo "$@" || :
 }
 
 vprintf() {
-  [[ "$VERBOSE" == "true" ]] && printf "$@"
+  [[ "$VERBOSE" == "true" ]] && printf "$@" || :
 }
 
 # Enable debug mode by setting DEBUG=true
@@ -81,7 +81,7 @@ if [[ -f "$_HOOK_SOURCE" ]]; then
   source "$_HOOK_SOURCE"
 else
   vecho "Optional hook-in script '$_HOOK_SOURCE' does not exist, skipping."
-  if [[ "$HOOKIN_SOURCE" != "$HOOKIN_SOURCE" ]]; then
+  if [[ "$HOOKIN_SOURCE" != "$HOOKIN_SOURCE_DEFAULT" ]]; then
     vecho "Optional hook-in script was non-default yet didn't exist. Exiting."
     return_code 127
   fi

--- a/devlog.md
+++ b/devlog.md
@@ -110,3 +110,51 @@ rm -rf .git/ && cd ~ && git init && git remote add origin git@github.com:Skenvy/
 ```
 
 </details>
+
+## PowerShell equivalents for Windows
+The first step to introducing Windows equivalents here, is to understand `$PROFILE`, and that there are "two" modern states of PowerShell that would need to be be supported.
+
+[Version 5.1](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-5.1#the-profile-variable) is a legacy version that is installed by default on Windows, built on [.NET Framework](https://en.wikipedia.org/wiki/.NET_Framework).
+
+[Version 7.x](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.6#the-profile-variable) are the modern [FLOSS](https://github.com/powershell/powershell) (`MIT`) versions of PowerShell "Core" (monikered so because it is built on [.NET Core](https://en.wikipedia.org/wiki/.NET) (now just `.NET`)).
+
+You can install the `7.x`'s on non-Windows OS, [see here](https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell?view=powershell-7.6).
+
+Knowing which one to support takes knowing which one we are likely to have or use.
+All Windows get Version 5.1, and can optionally also install one or more `7.x`'s along-side the built-in `5.1`.
+
+What _we_ need to know for _this_, though, is that `5.1` and the `7.x`'s have slightly differen values for `$PROFILE`, although they both provide us with a built in way to retrieve those values locally via;
+```powershell
+<# Current User, Current Host - #> $PROFILE # Default == .CurrentUserCurrentHost
+<# Current User, Current Host - #> $PROFILE.CurrentUserCurrentHost
+<# Current User, All Hosts - #> $PROFILE.CurrentUserAllHosts
+<# All Users, Current Host - #> $PROFILE.AllUsersCurrentHost
+<# All Users, All Hosts - #> $PROFILE.AllUsersAllHosts
+```
+### What is "host"???
+"Host" is a bit of a poison pill in these descriptions.. "host" here means "each individual app", e.g., "PowerShell" and "PowerShell ISE" are two different applications, and, according to this, two different _Hosts_...
+```pwsh
+Write-Host $PROFILE.CurrentUserCurrentHost # In PowerShell
+# $HOME\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+Write-Host $PROFILE.CurrentUserCurrentHost # In PowerShell ISE
+# $HOME\Documents\WindowsPowerShell\Microsoft.PowerShellISE_profile.ps1
+```
+The lesson here is that, typically, your "host" here in PowerShell land doesn't mean your machine, and, rather unintuitively without being accustomed to it yet, your machine / user can have many "host" `$PROFILE`'s, one for each application you use that uses PowerShell, in fact.
+### `.bashrc` equivalent
+We don't want to bother with maintaining a whole bunch of "per app" configs for pwsh yet, and, thankfully, the `$PROFILE.CurrentUserAllHosts` choice is more closely aligned with being a `.bashrc` equivalent. So we can add a `$PROFILE.CurrentUserAllHosts` (which seems to be `$HOME\Documents\WindowsPowerShell\profile.ps1` in `5.1`) to house all our:
+* Path modifications: `$env:Path += ";C:\some\folder\path"`
+* Aliases: `Set-Alias`
+* Custom functions: `function someFunc { ... }`
+* Environment variables: `$env:SOME_ENV = 'SOME_VAL'`
+* Module loads: `Import-Module`
+* etc.
+
+We can create / evaluate whether we already have one with an easy check
+```pwsh
+if (Test-Path $PROFILE.CurrentUserAllHosts) {
+    Write-Warning "Profile already exists! Skipping creation to prevent overwriting your settings."
+} else {
+    New-Item -Path $PROFILE.CurrentUserAllHosts -ItemType File -Force
+    Write-Host "Success: Blank profile skeleton created." -ForegroundColor Green
+}
+```

--- a/git/README.md
+++ b/git/README.md
@@ -52,14 +52,15 @@ See [git downloads](https://git-scm.com/downloads), it already has very helpful 
 * [_source_](https://git-scm.com/install/source) (if you choose this then you know what you're doing already)
 ## [`.gitignore`](https://git-scm.com/docs/gitignore)
 ### Global/Dotfiles
-> [!TIP]
-> Set your user global `.gitignore` with [`core.excludesFile`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile).
+> [!IMPORTANT]
+> Set your user **global** `.gitignore` with [`core.excludesFile`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile).
 > Local settings will take precedence.
 >
-> In the context of `.gitignore`, local precedence means that a pattern you ignore globally can be unignored by a local `.gitignore`, so you can't blindly trust your global `.gitignore` will always prevent every commit of every pattern it ignores, universally.
+> In the context of `.gitignore`, local precedence means that a pattern you ignore globally can be unignored by a local `.gitignore`, so you can't blindly trust your **global** `.gitignore` will always prevent every commit of every pattern it ignores, universally.
 >
 > We use [~/.config/git/.gitignore](../.config/git/.gitignore).
->
+
+> [!TIP]
 > We use several [github/gitignore:./Global](https://github.com/github/gitignore/tree/main/Global);
 > OS ignores:
 > [Linux](https://github.com/github/gitignore/blob/main/Global/Linux.gitignore),
@@ -69,6 +70,17 @@ See [git downloads](https://git-scm.com/downloads), it already has very helpful 
 > [Images](https://github.com/github/gitignore/blob/main/Global/Images.gitignore),
 > `node_modules/`,
 > `.ve/`, `.venv/`
+
+> [!NOTE]
+> `.gitignore` has no inclusion mechanism, and one isn't necessary either.
+>
+> As far as our **global** `.gitignore` is concerned, with regards to supporting _these_ dotfiles for use in devcontainers:
+> 1. Having the **global** `.gitignore` checked-in and...
+> 1. Referenced at a `$HOME`-relative location in our `~/.gitconfig.base` and...
+> 1. Pulled in to a devcontainer by a lifecycle step that supports installing from a dotfiles repository remote.
+>     * e.g. [vsc supports devcontainer dotfiles](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories)
+>
+> Is all we need to support our **global** `.gitignore` propagating in to a devcontainer build.
 ### Local/Repo
 More often than not, you will best be served by having a look at some pre-existing ignore templates.
 Of course, you should edit these as necessary, and some tools / languages might be more or less likely to _have_ a template you can start from.
@@ -80,13 +92,25 @@ We use a single `*` in the local ignore [here](../.gitignore), to ignore _everyt
 You can make an exception to an ignore pattern for a specific file, by `-f`'ing it e.g. `git add -f <ignored-file>`.
 ## [`.gitattributes`](https://git-scm.com/docs/gitattributes)
 ### Global/Dotfiles
-> [!TIP]
+> [!IMPORTANT]
 > Set your user global `.gitattributes` with [`core.attributesFile`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreattributesFile).
 > Local settings will take precedence.
 >
 > We use [~/.config/git/.gitattributes](../.config/git/.gitattributes).
->
+
+> [!TIP]
 > The below suggestion for what `.gitattributes` to use locally are also good for global settings.
+
+> [!NOTE]
+> `.gitattributes` has no inclusion mechanism, and one isn't necessary either.
+>
+> As far as our **global** `.gitattributes` is concerned, with regards to supporting _these_ dotfiles for use in devcontainers:
+> 1. Having the **global** `.gitattributes` checked-in and...
+> 1. Referenced at a `$HOME`-relative location in our `~/.gitconfig.base` and...
+> 1. Pulled in to a devcontainer by a lifecycle step that supports installing from a dotfiles repository remote.
+>     * e.g. [vsc supports devcontainer dotfiles](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories)
+>
+> Is all we need to support our **global** `.gitattributes` propagating in to a devcontainer build.
 ### Local/Repo
 The following is what we both use [here](../.gitattributes), and what we generally recommend anyone use in their `.gitattributes`, if you don't already have a good reason for using some other attributes.
 

--- a/git/README.md
+++ b/git/README.md
@@ -102,3 +102,17 @@ See docs:
 > If you're adding these to your `.gitattributes` later in development, remember to `git add --renormalize .` to apply these setting to the indexed state.
 > Then add and commit the renormalised indexed state, so any new clone / pull will get a fully normalised state.
 > Any future changes will get normalised by this `.gitattributes` as they happen, now.
+## [`.gitmodules`](https://git-scm.com/docs/gitmodules)
+Purely for completeness of including the last of the `.git*` files, we'll also mention `.gitmodules` here, although only as an honourable mention.
+### Global/Dotfiles
+_There are none._ It's not a thing.. at all..
+### Local/Repo
+`.gitmodules` only applies to the context of being defined on a repository, and lists other repositories that you want to have copies of embedded in the repository submoduling.
+From `git`'s perspective, a submodule is tracked in the repository that lists it in its own `.gitmodules` as the sha-pin of the submoduled repository.
+See the entry in the git book, [7.11 Git Tools - Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+Fwiw, some people have strong opinions on the difference between [submodule](https://www.atlassian.com/git/tutorials/git-submodule) and [subtree](https://www.atlassian.com/git/tutorials/git-subtree). I don't necessarily take a side in this, but they are worth reading if you are still shopping around.
+### _This repo_
+Even though "`.gitmodules` has no dotfiles component" is true _for `.gitmodules` itself,_ **this** is a _dotfiles repository_, that **does** have a suggested use case for which it provides a `.gitmodules` example that can be used to submodule **this repository** in to any other dotfiles repository.
+
+The "base" branch, an example of a dotfiles repository piggybacking off this via our provided [Use as "$HOME is another repo"](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#use-as-home-is-another-repo) methodology, provides this [`.gitmodules`](https://github.com/Skenvy/dotfiles/blob/base/.gitmodules) example.
+More specific instructions can be found under [Use as "$HOME is another repo" :: Starting from an existing repository](https://github.com/Skenvy/dotfiles/tree/main?tab=readme-ov-file#starting-from-an-existing-repository).

--- a/git/config/apply.sh
+++ b/git/config/apply.sh
@@ -65,11 +65,11 @@ if [ "$PRIOR_STATE" != "$TARGET_STATE" ]; then
   set +e
   diff <(echo "$PRIOR_STATE") <(echo "$TARGET_STATE") >> "$GITCONFIG_DIFF"
   set -e
-  echo "⚠️  WARNING: Git config has diverged from the managed configuration!"
-  echo "⚠️  Differences saved to: $GITCONFIG_DIFF"
-  echo "⚠️  Please review and merge any necessary custom settings."
-  echo # Newline
-  cat "$GITCONFIG_DIFF"
+  echo "⚠️  WARNING: Git config has diverged from the managed configuration!" >&2
+  echo "⚠️  Differences saved to: $GITCONFIG_DIFF" >&2
+  echo "⚠️  Please review and merge any necessary custom settings." >&2
+  echo >&2 # Newline
+  cat "$GITCONFIG_DIFF" >&2
 else
   echo "✅  Git config is in sync with managed configuration"
 fi


### PR DESCRIPTION
* add `gaconf` alias, in both bash, and in...
* NEW PowerShell dotfiles...
    * `v5.1` `CurrentUserAllHosts` Profile added
    * with alias source
* change `apply.sh` to print warning to stderr, and silence everything else when run in bashrc
* Add several fallback options for `system-bash-compat` in `dotfiles-submodule-symlinks`
* Fix `system-bash-compat` to use `|| :` NOPs to handle `VERBOSE=false` with `set -e`
* PowerShell dotfiles section in the devlog
* Extend the git config readme to include submodule mention, and note how global gitignore and gitattr get in to devcontainer builds